### PR TITLE
Add semantic reset methods

### DIFF
--- a/src/Module/WireMock.php
+++ b/src/Module/WireMock.php
@@ -18,7 +18,6 @@
 namespace Codeception\Module;
 
 use Codeception\Module as CodeceptionModule;
-use Codeception\TestCase;
 use Codeception\Util\Debug;
 use WireMock\Client\WireMock as WireMockClient;
 use WireMock\Client\MappingBuilder;

--- a/src/Module/WireMock.php
+++ b/src/Module/WireMock.php
@@ -86,4 +86,9 @@ class WireMock extends CodeceptionModule
     {
         $this->wireMock->reset();
     }
+
+    public function resetRequestJournalInWireMock()
+    {
+        $this->wireMock->resetAllRequests();
+    }
 }

--- a/src/Module/WireMock.php
+++ b/src/Module/WireMock.php
@@ -91,4 +91,9 @@ class WireMock extends CodeceptionModule
     {
         $this->wireMock->resetAllRequests();
     }
+
+    public function resetMappingsInWireMock()
+    {
+        $this->wireMock->resetToDefault();
+    }
 }

--- a/src/Module/WireMock.php
+++ b/src/Module/WireMock.php
@@ -48,6 +48,9 @@ class WireMock extends CodeceptionModule
         $this->wireMock = WireMockClient::create($this->config['host'], $this->config['port']);
     }
 
+    /**
+     * @deprecated use resetMappingsAndRequestJournalInWireMock() instead
+     */
     public function cleanAllPreviousRequestsToWireMock()
     {
         $this->wireMock->reset();
@@ -77,5 +80,10 @@ class WireMock extends CodeceptionModule
     public function findReceivedRequestsToWireMock(RequestPatternBuilder $builder)
     {
         return $this->wireMock->findAll($builder);
+    }
+
+    public function resetMappingsAndRequestJournalInWireMock()
+    {
+        $this->wireMock->reset();
     }
 }


### PR DESCRIPTION
Usually you want to have separated methods for request/mapping reset.

Old `cleanAllPreviousRequestsToWireMock` method naming was a bit misleading, so I add `resetMappingsAndRequestJournalInWireMock` to replace it.